### PR TITLE
Set uv version lower bound to >=0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ required-imports = ["from __future__ import annotations"]
 keep-runtime-typing = true
 
 [tool.uv]
-required-version = "<0.7"
+required-version = ">=0.7"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Updates uv version constraint from upper bound to lower bound (>=0.7) for better compatibility with newer uv versions.

This change allows the project to use any uv version 0.7 or higher, rather than restricting to versions below a certain threshold.